### PR TITLE
add Activation Event "aMi.startDebugAdaptor"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCommand:aMi.startMatlab"
+		"onCommand:aMi.startMatlab",
+		"onCommand:aMi.startDebugAdaptor",
 	],
 	"main": "./out/extension.js",
 	"contributes": {


### PR DESCRIPTION
There is an Error Popping up **Command `aMi.startDebugAdaptor` not found** whenever I try to execute the command.
![image](https://user-images.githubusercontent.com/60546840/154124039-2107e6f3-591e-4b0c-b51c-8d143c13cfea.png)

--------------------

**EXTRA Details**
I execute the command using a keyboard binding. That Keyboard binding will work in my MATLAB Workspace folder only.

I have configured that keyboard binding to run a task named `secondTask`. The `secondTask` task is defined in my WorkspaceFolder's `.vscode/tasks.json` .  So that `secondTask` will only work in my Workspace folder and not Globally everywhere

The `secondTask` task is used to run the `DebugAdaptor`

But whenever I tried to execute the command that command that Error Popup came up

So I referred https://stackoverflow.com/a/54797507/12872199 and made the changes for this PR.
